### PR TITLE
Allow configurable request key

### DIFF
--- a/src/ring/middleware/permacookie.clj
+++ b/src/ring/middleware/permacookie.clj
@@ -12,8 +12,9 @@
 (defn wrap-permacookie
   "Plant a permacookie on the browser."
   ([handler] (wrap-permacookie handler {}))
-  ([handler {:keys [name idfn expfn pathfn domainfn]
+  ([handler {:keys [name request-key idfn expfn pathfn domainfn]
              :or {name "permacookie"
+                  request-key :visitor-id
                   idfn (fn [r] (str (. UUID randomUUID)))
                   expfn (fn [r] "Sun, 01-Jan-2038 00:00:00 GMT")
                   pathfn (fn [r] "/")
@@ -24,16 +25,16 @@
          (except/throwf "No :cookies set on request."))
        (let [cookies (:cookies request)
              old-cookie (get cookies name)
-             visitor-id (if old-cookie (:value old-cookie) (idfn request))
-             new-cookie (permacookie visitor-id
+             current-value (if old-cookie (:value old-cookie) (idfn request))
+             new-cookie (permacookie current-value
                                      (expfn request)
                                      (pathfn request)
                                      (domainfn request))]
          (if old-cookie
            ;; don't need to set cookie cuz it's already here
-           (handler (assoc request :visitor-id visitor-id))
+           (handler (assoc request request-key current-value))
            ;; set it
-           (let [resp (handler (assoc request :visitor-id visitor-id))]
+           (let [resp (handler (assoc request request-key current-value))]
              (assoc resp :cookies (merge
                                    (:cookies resp)
                                    {name new-cookie}))))))))


### PR DESCRIPTION
- Allows the key of the permacookie value in the request map to be configurable, instead of hard-coding :visitor-id
